### PR TITLE
Fix incorrect cutout_size indexing

### DIFF
--- a/TESS-cont.py
+++ b/TESS-cont.py
@@ -137,7 +137,7 @@ except:
     
 try:
     cutout_size = OPTIONAL['cutout_size']
-    cutout_size = (int(cutout_size.split(',')[0]),                    int(cutout_size.split(',')[0]))
+    cutout_size = (int(cutout_size.split(',')[0]),                    int(cutout_size.split(',')[1]))
 except:
     cutout_size = (11,11) #@|similar to a tpf
     


### PR DESCRIPTION
Fixes a bug where both tuple entries were read from the first value of cutout_size.